### PR TITLE
Improve UI Design to Match React Flow's Official Style

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,20 +14,11 @@ function App() {
   return (
     <ThemeProvider defaultTheme={darkMode ? 'dark' : 'light'}>
       <ReactFlowProvider>
-        <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
+        <div className="min-h-screen flex flex-col">
           <Header darkMode={darkMode} toggleDarkMode={toggleDarkMode} />
           <main className="flex-1 p-4">
-            <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-4">
-              Mind Map TODO
-            </h1>
-            <p className="text-gray-600 dark:text-gray-400 mb-6">
-              Organize your tasks visually with this mind map-based TODO app. Click on nodes to expand and manage tasks.
-            </p>
             <MindMap />
           </main>
-          <footer className="py-3 px-4 text-center text-sm text-gray-500 dark:text-gray-400 border-t">
-            <p>Mind Map TODO - Click nodes to expand and manage tasks</p>
-          </footer>
         </div>
       </ReactFlowProvider>
     </ThemeProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,11 +14,20 @@ function App() {
   return (
     <ThemeProvider defaultTheme={darkMode ? 'dark' : 'light'}>
       <ReactFlowProvider>
-        <div className="min-h-screen flex flex-col">
+        <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
           <Header darkMode={darkMode} toggleDarkMode={toggleDarkMode} />
           <main className="flex-1 p-4">
+            <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-4">
+              Mind Map TODO
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
+              Organize your tasks visually with this mind map-based TODO app. Click on nodes to expand and manage tasks.
+            </p>
             <MindMap />
           </main>
+          <footer className="py-3 px-4 text-center text-sm text-gray-500 dark:text-gray-400 border-t">
+            <p>Mind Map TODO - Click nodes to expand and manage tasks</p>
+          </footer>
         </div>
       </ReactFlowProvider>
     </ThemeProvider>

--- a/src/components/MindMap.tsx
+++ b/src/components/MindMap.tsx
@@ -1,11 +1,14 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import ReactFlow, {
   Background,
   Controls,
   Node,
   NodeTypes,
+  Edge,
   Panel,
   useReactFlow,
+  ConnectionLineType,
+  MarkerType,
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 import { useMindMapStore } from '@/lib/store'
@@ -13,6 +16,22 @@ import TodoNode from './TodoNode'
 
 const nodeTypes: NodeTypes = {
   todoNode: TodoNode,
+}
+
+// Custom edge style
+const edgeOptions = {
+  style: { 
+    stroke: '#F59E0B', // Amber-500 (matching the orange node theme)
+    strokeWidth: 2 
+  },
+  type: 'smoothstep',
+  markerEnd: {
+    type: MarkerType.ArrowClosed,
+    color: '#F59E0B',
+    width: 15,
+    height: 15,
+  },
+  animated: true,
 }
 
 export default function MindMap() {
@@ -26,43 +45,66 @@ export default function MindMap() {
   } = useMindMapStore()
   
   const reactFlowInstance = useReactFlow()
+  const [isLoading, setIsLoading] = useState(false)
   
   const handleAddRootTodo = useCallback(() => {
+    setIsLoading(true)
     addTodo('root', 'New Task')
+    setTimeout(() => setIsLoading(false), 300)
   }, [addTodo])
   
   const handleAddStandaloneTodo = useCallback(() => {
+    setIsLoading(true)
     addTodo(null, 'New Standalone Task')
+    setTimeout(() => setIsLoading(false), 300)
   }, [addTodo])
   
   const fitView = useCallback(() => {
     reactFlowInstance.fitView({ padding: 0.2 })
   }, [reactFlowInstance])
   
+  // Mark the root node
+  const nodesWithRoot = nodes.map(node => {
+    if (node.id === 'root') {
+      return {
+        ...node,
+        data: {
+          ...node.data,
+          isRoot: true
+        }
+      }
+    }
+    return node
+  })
+  
   return (
-    <div className="w-full h-[calc(100vh-80px)] bg-background border rounded-lg">
+    <div className="w-full h-[calc(100vh-80px)] bg-gray-50 dark:bg-gray-900 border rounded-lg overflow-hidden">
       <ReactFlow
-        nodes={nodes}
+        nodes={nodesWithRoot}
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
         nodeTypes={nodeTypes}
         fitView
-        attributionPosition="bottom-right"
-        defaultEdgeOptions={{
-          type: 'smoothstep',
-          style: { stroke: '#6366f1', strokeWidth: 2 },
-          animated: true,
+        minZoom={0.2}
+        maxZoom={1.5}
+        defaultViewport={{ x: 0, y: 0, zoom: 0.8 }}
+        connectionLineType={ConnectionLineType.SmoothStep}
+        connectionLineStyle={{
+          stroke: '#F59E0B',
+          strokeWidth: 2,
         }}
+        defaultEdgeOptions={edgeOptions}
       >
-        <Background color="#aaa" gap={16} />
-        <Controls />
+        <Background color="#aaa" gap={16} size={1} />
+        <Controls position="bottom-right" showInteractive={false} />
         
         <Panel position="top-right" className="flex gap-2">
           <button
             onClick={handleAddRootTodo}
-            className="bg-primary text-primary-foreground p-2 rounded-md flex items-center gap-1 text-sm"
+            className="bg-orange-500 hover:bg-orange-600 text-white p-2 rounded-md flex items-center gap-1 text-sm transition-colors shadow-sm"
+            disabled={isLoading}
           >
             <span className="material-icons text-sm">add</span>
             Add Task
@@ -70,7 +112,8 @@ export default function MindMap() {
           
           <button
             onClick={handleAddStandaloneTodo}
-            className="bg-secondary text-secondary-foreground p-2 rounded-md flex items-center gap-1 text-sm"
+            className="bg-orange-400 hover:bg-orange-500 text-white p-2 rounded-md flex items-center gap-1 text-sm transition-colors shadow-sm"
+            disabled={isLoading}
           >
             <span className="material-icons text-sm">add_circle</span>
             Add Standalone
@@ -78,7 +121,7 @@ export default function MindMap() {
           
           <button
             onClick={fitView}
-            className="bg-secondary text-secondary-foreground p-2 rounded-md text-sm flex items-center gap-1"
+            className="bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 p-2 rounded-md text-sm flex items-center gap-1 transition-colors shadow-sm"
           >
             <span className="material-icons text-sm">fit_screen</span>
             Fit View

--- a/src/components/TodoNode.tsx
+++ b/src/components/TodoNode.tsx
@@ -8,11 +8,13 @@ interface TodoNodeData {
   id: string
   completed: boolean
   collapsed?: boolean
+  isRoot?: boolean
 }
 
-export default function TodoNode({ id, data }: NodeProps<TodoNodeData>) {
+export default function TodoNode({ id, data, selected }: NodeProps<TodoNodeData>) {
   const [isEditing, setIsEditing] = useState(false)
   const [text, setText] = useState(data.label)
+  const [isExpanded, setIsExpanded] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   
   const { 
@@ -26,6 +28,16 @@ export default function TodoNode({ id, data }: NodeProps<TodoNodeData>) {
   
   const todo = todos[id] as TodoNodeType
   const hasChildren = todo?.children && todo.children.length > 0
+  const isRoot = id === 'root' || data.isRoot
+  
+  // When node is selected, expand it
+  useEffect(() => {
+    if (selected) {
+      setIsExpanded(true)
+    } else {
+      setIsExpanded(false)
+    }
+  }, [selected])
   
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -65,44 +77,37 @@ export default function TodoNode({ id, data }: NodeProps<TodoNodeData>) {
   }
   
   return (
-    <div className={cn(
-      "border rounded-lg p-3 w-60 shadow-sm bg-card",
-      "transition-all hover:shadow-md",
-      data.completed ? "border-green-500 bg-green-50 dark:bg-green-950" : "border-border"
-    )}>
-      <Handle type="target" position={Position.Left} className="w-3 h-3 bg-blue-500" />
+    <div 
+      className={cn(
+        "rounded-md p-2 shadow-sm",
+        "transition-all duration-200",
+        isRoot 
+          ? "bg-orange-400 text-gray-900 min-w-[150px]" 
+          : "bg-orange-300 text-gray-900 min-w-[120px]",
+        selected || isExpanded 
+          ? "shadow-lg scale-110 z-10" 
+          : "hover:shadow-md"
+      )}
+      style={{ 
+        transition: 'all 0.2s ease'
+      }}
+    >
+      <Handle 
+        type="target" 
+        position={Position.Left} 
+        className="w-2 h-2 bg-orange-500 border-orange-600" 
+      />
       
-      <div className="flex items-center mb-2">
-        {hasChildren && (
-          <button 
-            onClick={handleToggleCollapse}
-            className="mr-1 p-1 rounded-full hover:bg-muted"
-          >
-            {data.collapsed ? (
-              <span className="material-icons text-sm">chevron_right</span>
-            ) : (
-              <span className="material-icons text-sm">expand_more</span>
-            )}
-          </button>
-        )}
+      <div className="flex items-center gap-1">
+        <div className="text-gray-700 mr-1">
+          <span className="material-icons text-base select-none">drag_indicator</span>
+        </div>
         
-        <button
-          onClick={handleToggleComplete}
-          className={cn(
-            "p-1 rounded-full",
-            data.completed ? "text-green-500 hover:text-green-600" : "text-muted-foreground hover:text-foreground"
-          )}
-        >
-          {data.completed ? (
-            <span className="material-icons">check_circle</span>
-          ) : (
-            <span className="material-icons">cancel</span>
-          )}
-        </button>
-      </div>
-      
-      <div className="flex flex-col">
-        {isEditing ? (
+        {!isEditing ? (
+          <div className="font-medium truncate">
+            {data.label}
+          </div>
+        ) : (
           <input
             ref={inputRef}
             type="text"
@@ -110,43 +115,76 @@ export default function TodoNode({ id, data }: NodeProps<TodoNodeData>) {
             onChange={(e) => setText(e.target.value)}
             onBlur={handleSave}
             onKeyDown={handleKeyDown}
-            className="bg-background p-2 border rounded mb-2"
+            className="bg-white/90 p-1 rounded text-sm w-full"
+            autoFocus
           />
-        ) : (
-          <p className={cn(
-            "font-medium mb-2",
-            data.completed && "line-through text-muted-foreground"
-          )}>
-            {data.label}
-          </p>
         )}
-        
-        <div className="flex justify-end space-x-1 mt-2">
+      </div>
+      
+      {(selected || isExpanded) && (
+        <div className="flex mt-2 justify-end space-x-1 animate-in fade-in zoom-in duration-200">
+          {hasChildren && (
+            <button 
+              onClick={handleToggleCollapse}
+              className="p-1 rounded-full hover:bg-orange-200 text-gray-700"
+              title={data.collapsed ? "Expand" : "Collapse"}
+            >
+              {data.collapsed ? (
+                <span className="material-icons text-sm">chevron_right</span>
+              ) : (
+                <span className="material-icons text-sm">expand_more</span>
+              )}
+            </button>
+          )}
+          
+          <button
+            onClick={handleToggleComplete}
+            className={cn(
+              "p-1 rounded-full hover:bg-orange-200",
+              data.completed ? "text-green-600" : "text-gray-700"
+            )}
+            title={data.completed ? "Mark as incomplete" : "Mark as complete"}
+          >
+            {data.completed ? (
+              <span className="material-icons text-sm">check_circle</span>
+            ) : (
+              <span className="material-icons text-sm">radio_button_unchecked</span>
+            )}
+          </button>
+          
           <button
             onClick={handleEdit}
-            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
+            className="p-1 rounded-full hover:bg-orange-200 text-gray-700"
+            title="Edit"
           >
             <span className="material-icons text-sm">edit</span>
           </button>
           
-          <button
-            onClick={handleDelete}
-            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-destructive"
-            disabled={id === 'root'}
-          >
-            <span className="material-icons text-sm">delete</span>
-          </button>
+          {!isRoot && (
+            <button
+              onClick={handleDelete}
+              className="p-1 rounded-full hover:bg-orange-200 text-gray-700"
+              title="Delete"
+            >
+              <span className="material-icons text-sm">delete</span>
+            </button>
+          )}
           
           <button
             onClick={handleAddChild}
-            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
+            className="p-1 rounded-full hover:bg-orange-200 text-gray-700"
+            title="Add child task"
           >
             <span className="material-icons text-sm">add</span>
           </button>
         </div>
-      </div>
+      )}
       
-      <Handle type="source" position={Position.Right} className="w-3 h-3 bg-blue-500" />
+      <Handle 
+        type="source" 
+        position={Position.Right} 
+        className="w-2 h-2 bg-orange-500 border-orange-600" 
+      />
     </div>
   )
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -37,7 +37,13 @@ const initialNodes: Node[] = [
   {
     id: 'root',
     type: 'todoNode',
-    data: { label: 'Main Tasks', id: 'root', completed: false, collapsed: false },
+    data: { 
+      label: 'Main Tasks', 
+      id: 'root', 
+      completed: false, 
+      collapsed: false,
+      isRoot: true
+    },
     position: { x: 0, y: 0 },
   },
 ]
@@ -78,7 +84,11 @@ export const useMindMapStore = create<MindMapState>()(
       
       onConnect: (connection: Connection) => {
         set({
-          edges: addEdge({ ...connection, type: 'smoothstep' }, get().edges),
+          edges: addEdge({ 
+            ...connection, 
+            type: 'smoothstep',
+            style: { stroke: '#F59E0B', strokeWidth: 2 }
+          }, get().edges),
         })
       },
       
@@ -107,7 +117,7 @@ export const useMindMapStore = create<MindMapState>()(
             // Calculate position relative to parent
             const parentChildren = parent.children || []
             position.x = parentNode.position.x + 250
-            position.y = parentNode.position.y + (parentChildren.length * 100)
+            position.y = parentNode.position.y + (parentChildren.length * 80) - (parentChildren.length > 0 ? 40 * parentChildren.length : 0)
             
             // Create an edge from parent to new node
             const newEdge: Edge = {
@@ -115,6 +125,8 @@ export const useMindMapStore = create<MindMapState>()(
               source: parentId,
               target: id,
               type: 'smoothstep',
+              style: { stroke: '#F59E0B', strokeWidth: 2 },
+              animated: true
             }
             
             set({
@@ -137,6 +149,13 @@ export const useMindMapStore = create<MindMapState>()(
           }
         } else {
           // Add as a top-level node if no parent
+          // Find root node for positioning
+          const rootNode = get().nodes.find(node => node.id === 'root')
+          const rootPosition = rootNode ? rootNode.position : { x: 0, y: 0 }
+          
+          position.x = rootPosition.x - 250 // Position to the left of root
+          position.y = rootPosition.y + get().nodes.length * 80 - 100
+          
           set({
             todos: {
               ...get().todos,
@@ -148,7 +167,7 @@ export const useMindMapStore = create<MindMapState>()(
                 id,
                 type: 'todoNode',
                 data: { label: text, id, completed: false, collapsed: false },
-                position: { x: 0, y: get().nodes.length * 100 },
+                position,
               },
             ],
           })


### PR DESCRIPTION
## 変更内容

このPRでは、マインドマップTODOアプリのUIデザインを改善し、React Flow公式サイトのスタイルに合わせました。

### 主な変更点

1. **ノードデザインの改善**
   - オレンジ色の角丸長方形スタイルの適用
   - ノード左側に「::」風の表示（Material Iconsの「drag_indicator」を使用）
   - ルートノードに特別なスタイルを適用して識別しやすく

2. **ノードインタラクションの向上**
   - ノードクリック時に拡大表示
   - クリック時のみアクションボタンを表示
   - 軽快なアニメーション効果の追加

3. **エッジ（線）のスタイル改善**
   - オレンジ色のエッジスタイル
   - 滑らかな曲線と矢印の追加
   - アニメーション効果の適用

4. **全体的なレイアウトの向上**
   - ノード配置のロジック改善
   - 視覚的階層構造の強化
   - 余分なスクロール領域の排除

### スクリーンショット
![Mind Map Screenshot](https://raw.githubusercontent.com/reactflow/reactflow/main/examples/basic/src/preview.png)
（上記はReact Flow公式のサンプル画像ですが、今回の実装も同様のデザインに近づけています）

### テスト方法
1. アプリを起動
2. 「Add Task」または「Add Standalone」ボタンでタスク追加
3. ノードをクリックしてアクション表示
4. 各種機能（編集・削除・完了トグル・子タスク追加）をテスト