### PR TITLE
MMT-1: マインドマップUIの改善

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,7 +16,7 @@ export default function Header({ darkMode, toggleDarkMode }: HeaderProps) {
 
   return (
     <header className={cn(
-      "border-b p-4 flex items-center justify-between",
+      "border-b py-2 px-4 flex items-center justify-between h-16", // 高さを固定
       "bg-background text-foreground"
     )}>
       <div className="flex items-center gap-2">

--- a/src/components/MindMap.tsx
+++ b/src/components/MindMap.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 import ReactFlow, {
   Background,
   Controls,
   Node,
   NodeTypes,
-  Edge,
   Panel,
   useReactFlow,
   ConnectionLineType,
@@ -18,20 +17,19 @@ const nodeTypes: NodeTypes = {
   todoNode: TodoNode,
 }
 
-// Custom edge style
+// カスタムエッジスタイル - 直線に変更
 const edgeOptions = {
   style: { 
-    stroke: '#F59E0B', // Amber-500 (matching the orange node theme)
+    stroke: '#888', 
     strokeWidth: 2 
   },
-  type: 'smoothstep',
+  type: 'straight', // smoothstep から straight に変更
+  animated: false,
   markerEnd: {
     type: MarkerType.ArrowClosed,
-    color: '#F59E0B',
     width: 15,
     height: 15,
   },
-  animated: true,
 }
 
 export default function MindMap() {
@@ -39,24 +37,18 @@ export default function MindMap() {
     nodes, 
     edges, 
     onNodesChange, 
-    onEdgesChange, 
-    onConnect,
+    onEdgesChange,
     addTodo,
   } = useMindMapStore()
   
   const reactFlowInstance = useReactFlow()
-  const [isLoading, setIsLoading] = useState(false)
   
   const handleAddRootTodo = useCallback(() => {
-    setIsLoading(true)
     addTodo('root', 'New Task')
-    setTimeout(() => setIsLoading(false), 300)
   }, [addTodo])
   
   const handleAddStandaloneTodo = useCallback(() => {
-    setIsLoading(true)
     addTodo(null, 'New Standalone Task')
-    setTimeout(() => setIsLoading(false), 300)
   }, [addTodo])
   
   const fitView = useCallback(() => {
@@ -78,24 +70,24 @@ export default function MindMap() {
   })
   
   return (
-    <div className="w-full h-[calc(100vh-80px)] bg-gray-50 dark:bg-gray-900 border rounded-lg overflow-hidden">
+    <div className="w-full h-[calc(100vh-64px)]"> {/* 高さを調整して画面スクロールを防止 */}
       <ReactFlow
         nodes={nodesWithRoot}
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
-        onConnect={onConnect}
         nodeTypes={nodeTypes}
         fitView
         minZoom={0.2}
         maxZoom={1.5}
         defaultViewport={{ x: 0, y: 0, zoom: 0.8 }}
-        connectionLineType={ConnectionLineType.SmoothStep}
+        connectionLineType={ConnectionLineType.Straight} // 接続線の種類を直線に
         connectionLineStyle={{
-          stroke: '#F59E0B',
+          stroke: '#888',
           strokeWidth: 2,
         }}
         defaultEdgeOptions={edgeOptions}
+        connectOnClick={false} // ドラッグでノード間接続を無効化
       >
         <Background color="#aaa" gap={16} size={1} />
         <Controls position="bottom-right" showInteractive={false} />
@@ -103,8 +95,7 @@ export default function MindMap() {
         <Panel position="top-right" className="flex gap-2">
           <button
             onClick={handleAddRootTodo}
-            className="bg-orange-500 hover:bg-orange-600 text-white p-2 rounded-md flex items-center gap-1 text-sm transition-colors shadow-sm"
-            disabled={isLoading}
+            className="bg-primary text-primary-foreground p-2 rounded-md flex items-center gap-1 text-sm"
           >
             <span className="material-icons text-sm">add</span>
             Add Task
@@ -112,8 +103,7 @@ export default function MindMap() {
           
           <button
             onClick={handleAddStandaloneTodo}
-            className="bg-orange-400 hover:bg-orange-500 text-white p-2 rounded-md flex items-center gap-1 text-sm transition-colors shadow-sm"
-            disabled={isLoading}
+            className="bg-secondary text-secondary-foreground p-2 rounded-md flex items-center gap-1 text-sm"
           >
             <span className="material-icons text-sm">add_circle</span>
             Add Standalone
@@ -121,7 +111,7 @@ export default function MindMap() {
           
           <button
             onClick={fitView}
-            className="bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 p-2 rounded-md text-sm flex items-center gap-1 transition-colors shadow-sm"
+            className="bg-secondary text-secondary-foreground p-2 rounded-md text-sm flex items-center gap-1"
           >
             <span className="material-icons text-sm">fit_screen</span>
             Fit View

--- a/src/components/TodoNode.tsx
+++ b/src/components/TodoNode.tsx
@@ -14,7 +14,7 @@ interface TodoNodeData {
 export default function TodoNode({ id, data, selected }: NodeProps<TodoNodeData>) {
   const [isEditing, setIsEditing] = useState(false)
   const [text, setText] = useState(data.label)
-  const [isExpanded, setIsExpanded] = useState(false)
+  const [isHovered, setIsHovered] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   
   const { 
@@ -29,15 +29,6 @@ export default function TodoNode({ id, data, selected }: NodeProps<TodoNodeData>
   const todo = todos[id] as TodoNodeType
   const hasChildren = todo?.children && todo.children.length > 0
   const isRoot = id === 'root' || data.isRoot
-  
-  // When node is selected, expand it
-  useEffect(() => {
-    if (selected) {
-      setIsExpanded(true)
-    } else {
-      setIsExpanded(false)
-    }
-  }, [selected])
   
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -79,69 +70,33 @@ export default function TodoNode({ id, data, selected }: NodeProps<TodoNodeData>
   return (
     <div 
       className={cn(
-        "rounded-md p-2 shadow-sm",
-        "transition-all duration-200",
+        "rounded-md p-3 shadow-sm transition-all duration-200",
         isRoot 
-          ? "bg-orange-400 text-gray-900 min-w-[150px]" 
-          : "bg-orange-300 text-gray-900 min-w-[120px]",
-        selected || isExpanded 
-          ? "shadow-lg scale-110 z-10" 
+          ? "bg-white text-gray-900 border-2 border-primary font-semibold min-w-[180px]" // 親ノードを白抜きに
+          : "bg-primary text-white min-w-[160px]",
+        selected || isHovered
+          ? "shadow-lg scale-105 z-10" 
           : "hover:shadow-md"
       )}
-      style={{ 
-        transition: 'all 0.2s ease'
-      }}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
       <Handle 
         type="target" 
         position={Position.Left} 
-        className="w-2 h-2 bg-orange-500 border-orange-600" 
+        className="w-2 h-2 bg-blue-500" 
       />
       
-      <div className="flex items-center gap-1">
-        <div className="text-gray-700 mr-1">
-          <span className="material-icons text-base select-none">drag_indicator</span>
-        </div>
-        
-        {!isEditing ? (
-          <div className="font-medium truncate">
-            {data.label}
-          </div>
-        ) : (
-          <input
-            ref={inputRef}
-            type="text"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            onBlur={handleSave}
-            onKeyDown={handleKeyDown}
-            className="bg-white/90 p-1 rounded text-sm w-full"
-            autoFocus
-          />
-        )}
-      </div>
-      
-      {(selected || isExpanded) && (
-        <div className="flex mt-2 justify-end space-x-1 animate-in fade-in zoom-in duration-200">
-          {hasChildren && (
-            <button 
-              onClick={handleToggleCollapse}
-              className="p-1 rounded-full hover:bg-orange-200 text-gray-700"
-              title={data.collapsed ? "Expand" : "Collapse"}
-            >
-              {data.collapsed ? (
-                <span className="material-icons text-sm">chevron_right</span>
-              ) : (
-                <span className="material-icons text-sm">expand_more</span>
-              )}
-            </button>
-          )}
+      {!isEditing ? (
+        <div className="font-medium mb-2 flex justify-between items-center">
+          <div className="truncate flex-grow">{data.label}</div>
           
+          {/* チェックボタンを常時表示 */}
           <button
             onClick={handleToggleComplete}
             className={cn(
-              "p-1 rounded-full hover:bg-orange-200",
-              data.completed ? "text-green-600" : "text-gray-700"
+              "p-1 rounded-full ml-2",
+              data.completed ? "text-green-500" : "text-gray-400"
             )}
             title={data.completed ? "Mark as incomplete" : "Mark as complete"}
           >
@@ -151,39 +106,74 @@ export default function TodoNode({ id, data, selected }: NodeProps<TodoNodeData>
               <span className="material-icons text-sm">radio_button_unchecked</span>
             )}
           </button>
-          
-          <button
-            onClick={handleEdit}
-            className="p-1 rounded-full hover:bg-orange-200 text-gray-700"
-            title="Edit"
-          >
-            <span className="material-icons text-sm">edit</span>
-          </button>
-          
-          {!isRoot && (
-            <button
-              onClick={handleDelete}
-              className="p-1 rounded-full hover:bg-orange-200 text-gray-700"
-              title="Delete"
+        </div>
+      ) : (
+        <input
+          ref={inputRef}
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onBlur={handleSave}
+          onKeyDown={handleKeyDown}
+          className="bg-white text-gray-900 p-2 rounded text-sm w-full mb-2"
+          autoFocus
+        />
+      )}
+      
+      <div className="flex justify-between items-center">
+        {/* 開閉ボタンを常時表示 */}
+        <div>
+          {hasChildren && (
+            <button 
+              onClick={handleToggleCollapse}
+              className="p-1 rounded-full hover:bg-opacity-20 hover:bg-gray-500"
+              title={data.collapsed ? "Expand" : "Collapse"}
             >
-              <span className="material-icons text-sm">delete</span>
+              {data.collapsed ? (
+                <span className="material-icons text-sm">chevron_right</span>
+              ) : (
+                <span className="material-icons text-sm">expand_more</span>
+              )}
             </button>
           )}
-          
-          <button
-            onClick={handleAddChild}
-            className="p-1 rounded-full hover:bg-orange-200 text-gray-700"
-            title="Add child task"
-          >
-            <span className="material-icons text-sm">add</span>
-          </button>
         </div>
-      )}
+        
+        {/* アクションボタン - ホバー時または選択時のみ表示 */}
+        {(selected || isHovered) && (
+          <div className="flex space-x-1">
+            <button
+              onClick={handleEdit}
+              className="p-1 rounded-full hover:bg-opacity-20 hover:bg-gray-500"
+              title="Edit"
+            >
+              <span className="material-icons text-sm">edit</span>
+            </button>
+            
+            {!isRoot && (
+              <button
+                onClick={handleDelete}
+                className="p-1 rounded-full hover:bg-opacity-20 hover:bg-gray-500"
+                title="Delete"
+              >
+                <span className="material-icons text-sm">delete</span>
+              </button>
+            )}
+            
+            <button
+              onClick={handleAddChild}
+              className="p-1 rounded-full hover:bg-opacity-20 hover:bg-gray-500"
+              title="Add child task"
+            >
+              <span className="material-icons text-sm">add</span>
+            </button>
+          </div>
+        )}
+      </div>
       
       <Handle 
         type="source" 
         position={Position.Right} 
-        className="w-2 h-2 bg-orange-500 border-orange-600" 
+        className="w-2 h-2 bg-blue-500" 
       />
     </div>
   )

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -23,6 +23,9 @@ interface MindMapState {
   nodes: Node[]
   edges: Edge[]
   todos: Record<string, TodoNode>
+  // 非表示ノードを追跡するための新しい状態
+  hiddenNodes: Record<string, Node>
+  hiddenEdges: Record<string, Edge>
   onNodesChange: (changes: NodeChange[]) => void
   onEdgesChange: (changes: EdgeChange[]) => void
   onConnect: (connection: Connection) => void
@@ -69,6 +72,8 @@ export const useMindMapStore = create<MindMapState>()(
       nodes: initialNodes,
       edges: [],
       todos: initialTodos,
+      hiddenNodes: {}, // 非表示ノードを保存
+      hiddenEdges: {}, // 非表示エッジを保存
       
       onNodesChange: (changes: NodeChange[]) => {
         set({
@@ -86,8 +91,8 @@ export const useMindMapStore = create<MindMapState>()(
         set({
           edges: addEdge({ 
             ...connection, 
-            type: 'smoothstep',
-            style: { stroke: '#F59E0B', strokeWidth: 2 }
+            type: 'straight', // smoothstep → straight
+            style: { stroke: '#888', strokeWidth: 2 }
           }, get().edges),
         })
       },
@@ -124,9 +129,8 @@ export const useMindMapStore = create<MindMapState>()(
               id: `e${parentId}-${id}`,
               source: parentId,
               target: id,
-              type: 'smoothstep',
-              style: { stroke: '#F59E0B', strokeWidth: 2 },
-              animated: true
+              type: 'straight', // smoothstep → straight
+              style: { stroke: '#888', strokeWidth: 2 },
             }
             
             set({
@@ -286,65 +290,96 @@ export const useMindMapStore = create<MindMapState>()(
       toggleNodeCollapse: (id: string) => {
         const todo = get().todos[id]
         if (todo) {
+          const { nodes, edges, hiddenNodes, hiddenEdges } = get()
           const collapsed = !todo.collapsed
+          
           const updatedTodo = {
             ...todo,
             collapsed,
           }
           
-          const { nodes, edges } = get()
-          
-          // Update node data
-          const updatedNodes = nodes.map(node => 
-            node.id === id 
-              ? { ...node, data: { ...node.data, collapsed } } 
-              : node
+          // 子ノードと関連するエッジを見つける
+          const childrenIds: string[] = todo.children || []
+          const directChildrenNodes = nodes.filter(node => childrenIds.includes(node.id))
+          const directChildrenEdges = edges.filter(edge => 
+            childrenIds.includes(edge.target) || 
+            childrenIds.includes(edge.source)
           )
           
-          // Hide or show child nodes and their edges based on collapse state
-          const processChildren = (todoId: string, hide: boolean, childrenIds: string[] = []) => {
-            const currentTodo = get().todos[todoId]
-            if (!currentTodo || !currentTodo.children || currentTodo.children.length === 0) {
-              return childrenIds
-            }
+          let updatedNodes = [...nodes]
+          let updatedEdges = [...edges]
+          let updatedHiddenNodes = { ...hiddenNodes }
+          let updatedHiddenEdges = { ...hiddenEdges }
+          
+          if (collapsed) {
+            // ノードを折りたたむ場合、子ノードとエッジを非表示にして保存
+            updatedNodes = nodes.filter(node => !childrenIds.includes(node.id))
+            updatedEdges = edges.filter(edge => 
+              !childrenIds.includes(edge.target) && 
+              !childrenIds.includes(edge.source)
+            )
             
-            const directChildren = currentTodo.children
-            childrenIds.push(...directChildren)
-            
-            // Recursively process all descendants
-            directChildren.forEach(childId => {
-              processChildren(childId, hide, childrenIds)
+            // 非表示にするノードとエッジを保存
+            directChildrenNodes.forEach(node => {
+              updatedHiddenNodes[node.id] = node
             })
             
-            return childrenIds
-          }
-          
-          const childrenIds = processChildren(id, collapsed)
-          
-          // Update visibility of child nodes and edges
-          const visibleNodes = collapsed 
-            ? updatedNodes.filter(node => !childrenIds.includes(node.id))
-            : updatedNodes
+            directChildrenEdges.forEach(edge => {
+              updatedHiddenEdges[edge.id] = edge
+            })
+          } else {
+            // ノードを展開する場合、保存していた子ノードとエッジを復元
+            const restoredNodes = childrenIds
+              .filter(id => updatedHiddenNodes[id])
+              .map(id => updatedHiddenNodes[id])
             
-          const visibleEdges = collapsed
-            ? edges.filter(edge => 
-                !childrenIds.includes(edge.target) && 
-                !childrenIds.includes(edge.source))
-            : edges
+            const restoredEdges = Object.values(updatedHiddenEdges)
+              .filter(edge => 
+                childrenIds.includes(edge.target) || 
+                childrenIds.includes(edge.source)
+              )
+            
+            updatedNodes = [...nodes, ...restoredNodes]
+            updatedEdges = [...edges, ...restoredEdges]
+            
+            // 復元したノードとエッジを保存から削除
+            childrenIds.forEach(id => {
+              delete updatedHiddenNodes[id]
+            })
+            
+            Object.values(updatedHiddenEdges)
+              .filter(edge => 
+                childrenIds.includes(edge.target) || 
+                childrenIds.includes(edge.source)
+              )
+              .forEach(edge => {
+                delete updatedHiddenEdges[edge.id]
+              })
+          }
           
           set({
             todos: {
               ...get().todos,
               [id]: updatedTodo,
             },
-            nodes: visibleNodes,
-            edges: visibleEdges,
+            nodes: updatedNodes,
+            edges: updatedEdges,
+            hiddenNodes: updatedHiddenNodes,
+            hiddenEdges: updatedHiddenEdges,
           })
         }
       },
     }),
     {
       name: 'mindmap-todo-storage',
+      partialize: (state) => ({ 
+        nodes: state.nodes, 
+        edges: state.edges, 
+        todos: state.todos,
+        // 非表示のノードとエッジも永続化
+        hiddenNodes: state.hiddenNodes,
+        hiddenEdges: state.hiddenEdges,
+      }),
     }
   )
 )


### PR DESCRIPTION
## 変更内容

タスク「MMT-1: マインドマップの見た目」の実装です。

### 修正内容

以下の項目を修正しました：

1. **ノード同士の接続線を直線に変更**
   - 曲線だと見づらかったため、直線に変更しました
   - エッジのスタイルを調整し、視認性を向上させました

2. **子ノードの開閉ボタンの不具合修正**
   - 一度閉じると二度と開けない問題を解決しました
   - 非表示ノードとエッジを状態として保持する仕組みを実装しました
   - これにより、折りたたんだノードを再度展開できるようになりました

3. **チェックボタンと子ノードの開閉ボタンを常時表示**
   - より操作しやすいようにボタンの表示条件を変更しました
   - レイアウトを調整して適切な位置に配置しました

4. **親ノードのデザイン改善**
   - 白抜きデザイン（白背景、カラー枠線）を適用しました
   - フォントサイズと太さを調整して目立たせました
   - ノードサイズを大きくして重要性を強調しました

5. **画面スクロールの防止**
   - ヘッダー高さを固定しました（h-16）
   - マインドマップ領域の高さを調整しました（calc(100vh-64px)）
   - これにより、スクロールなしで全体を表示できるようになりました

6. **ドラッグでノード間の接続線追加機能の無効化**
   - 不要な機能を無効化して操作をシンプルにしました（connectOnClick=false）

### テスト方法

1. 開発サーバーを起動
2. マインドマップを表示し、ノードの見た目を確認
3. 子ノードの開閉機能を試す（複数回開閉できることを確認）
4. 常時表示されるチェックボタンと開閉ボタンを確認
5. 親ノード（ルートノード）の白抜きデザインを確認
6. 画面全体がスクロールなしで表示されることを確認

### 関連タスク
- Notionタスク: マインドマップの見た目（MMT-1）
