### PR TITLE
MMT-4: マインドマップの保存機能実装

### DIFF
--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -65,6 +65,11 @@ function Flow() {
   const connectingNodeRef = useRef<string | null>(null);
   const reactFlowInstance = useReactFlow();
   const [searchHighlightedNodes, setSearchHighlightedNodes] = useState<string[]>([]);
+  
+  // サイドパネルの表示モードを管理
+  const [sidePanelMode, setSidePanelMode] = useState<string>('tree');
+  // サイドパネルの表示/非表示
+  const [showSidePanel, setShowSidePanel] = useState<boolean>(true);
 
   // アプリが初期化されるときにストレージから読み込む
   useEffect(() => {
@@ -162,9 +167,25 @@ function Flow() {
     }
   };
 
+  // ナビゲーションアイテムがクリックされたときの処理
+  const handleNavigationItemClick = (item: string) => {
+    // treeとstorageの場合はサイドパネルモードを設定し、パネルを表示
+    if (item === 'tree' || item === 'storage') {
+      setSidePanelMode(item);
+      setShowSidePanel(true);
+    } else {
+      // それ以外のアイテム（account, projectsなど）はサイドパネルを非表示に
+      // ※必要に応じて他のUIコンポーネントを表示する処理を追加
+      setShowSidePanel(false);
+    }
+  };
+
   return (
     <div className="flex h-screen">
-      <NavigationBar />
+      <NavigationBar 
+        activeItem={sidePanelMode} 
+        onItemClick={handleNavigationItemClick} 
+      />
       <div className="flex-1 ml-16">
         <ReactFlow
           nodes={nodes.map(node => ({
@@ -189,7 +210,7 @@ function Flow() {
           maxZoom={1.5}
         >
           <Header onSearch={handleSearch} />
-          <SidePanel />
+          {showSidePanel && <SidePanel mode={sidePanelMode} />}
           <Controls showInteractive={false} />
           <Background variant={BackgroundVariant.Dots} gap={16} size={2} color="#F6AD55" />
         </ReactFlow>

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState, useEffect } from 'react';
 import ReactFlow, {
   ConnectionLineType,
   NodeOrigin,
@@ -30,6 +30,9 @@ const selector = (state: RFState) => ({
   onNodesChange: state.onNodesChange,
   onEdgesChange: state.onEdgesChange,
   addChildNode: state.addChildNode,
+  loadFromStorage: state.loadFromStorage,
+  initialized: state.initialized,
+  setInitialized: state.setInitialized,
 });
 
 const nodeTypes = {
@@ -47,14 +50,29 @@ const defaultEdgeOptions = { style: connectionLineStyle, type: 'mindmap' };
 
 function Flow() {
   const store = useStoreApi();
-  const { nodes, edges, onNodesChange, onEdgesChange, addChildNode } = useStore(
-    selector,
-    shallow
-  );
+  const { 
+    nodes, 
+    edges, 
+    onNodesChange, 
+    onEdgesChange, 
+    addChildNode,
+    loadFromStorage,
+    initialized,
+    setInitialized
+  } = useStore(selector, shallow);
+  
   const [connectingNodeId, setConnectingNodeId] = useState<string | null>(null);
   const connectingNodeRef = useRef<string | null>(null);
   const reactFlowInstance = useReactFlow();
   const [searchHighlightedNodes, setSearchHighlightedNodes] = useState<string[]>([]);
+
+  // アプリが初期化されるときにストレージから読み込む
+  useEffect(() => {
+    if (!initialized) {
+      console.log('マインドマップデータをストレージから読み込みます');
+      loadFromStorage();
+    }
+  }, [initialized, loadFromStorage]);
 
   const getChildNodePosition = (event: MouseEvent, parentNode?: Node) => {
     const { domNode } = store.getState();

--- a/src/App/store.ts
+++ b/src/App/store.ts
@@ -13,6 +13,7 @@ import create from 'zustand';
 import { nanoid } from 'nanoid/non-secure';
 
 import { NodeData } from './MindMapNode';
+import { loadMindMapFromStorage, saveMindMapToStorage } from '../utils/storage';
 
 export type RFState = {
   nodes: Node<NodeData>[];
@@ -22,29 +23,54 @@ export type RFState = {
   updateNodeLabel: (nodeId: string, label: string) => void;
   addChildNode: (parentNode: Node, position: XYPosition) => void;
   toggleNodeCollapse: (nodeId: string) => void;
+  loadFromStorage: () => void;
+  saveToStorage: () => void;
+  initialized: boolean;
+  setInitialized: (value: boolean) => void;
 };
 
+// デフォルトのノードとエッジ
+const defaultNodes: Node<NodeData>[] = [
+  {
+    id: 'root',
+    type: 'mindmap',
+    data: { label: 'React Flow Mind Map', collapsed: false },
+    position: { x: 0, y: 0 },
+    dragHandle: '.dragHandle',
+  },
+];
+const defaultEdges: Edge[] = [];
+
 const useStore = create<RFState>((set, get) => ({
-  nodes: [
-    {
-      id: 'root',
-      type: 'mindmap',
-      data: { label: 'React Flow Mind Map', collapsed: false },
-      position: { x: 0, y: 0 },
-      dragHandle: '.dragHandle',
-    },
-  ],
-  edges: [],
+  // 初期化フラグ
+  initialized: false,
+  setInitialized: (value: boolean) => set({ initialized: value }),
+
+  // デフォルト値で初期化
+  nodes: [...defaultNodes],
+  edges: [...defaultEdges],
+
+  // ノード変更
   onNodesChange: (changes: NodeChange[]) => {
     set({
       nodes: applyNodeChanges(changes, get().nodes),
     });
+    
+    // 変更があった時に自動保存
+    setTimeout(() => get().saveToStorage(), 0);
   },
+
+  // エッジ変更
   onEdgesChange: (changes: EdgeChange[]) => {
     set({
       edges: applyEdgeChanges(changes, get().edges),
     });
+    
+    // 変更があった時に自動保存
+    setTimeout(() => get().saveToStorage(), 0);
   },
+
+  // ノードラベル更新
   updateNodeLabel: (nodeId: string, label: string) => {
     set({
       nodes: get().nodes.map((node) => {
@@ -56,7 +82,12 @@ const useStore = create<RFState>((set, get) => ({
         return node;
       }),
     });
+    
+    // 変更があった時に自動保存
+    setTimeout(() => get().saveToStorage(), 0);
   },
+
+  // 子ノード追加
   addChildNode: (parentNode: Node, position: XYPosition) => {
     const newNode = {
       id: nanoid(),
@@ -77,7 +108,12 @@ const useStore = create<RFState>((set, get) => ({
       nodes: [...get().nodes, newNode],
       edges: [...get().edges, newEdge],
     });
+    
+    // 変更があった時に自動保存
+    setTimeout(() => get().saveToStorage(), 0);
   },
+
+  // ノードの折りたたみトグル
   toggleNodeCollapse: (nodeId: string) => {
     // ノードの展開/折りたたみ状態を切り替える
     const nodes = get().nodes.map((node) => {
@@ -140,7 +176,50 @@ const useStore = create<RFState>((set, get) => ({
       nodes: updatedNodes,
       edges: updatedEdges
     });
+    
+    // 変更があった時に自動保存
+    setTimeout(() => get().saveToStorage(), 0);
   },
+
+  // ストレージから読み込み
+  loadFromStorage: () => {
+    try {
+      const data = loadMindMapFromStorage();
+      
+      if (data) {
+        set({
+          nodes: data.nodes,
+          edges: data.edges,
+          initialized: true
+        });
+        console.log('ストレージからマインドマップを読み込みました');
+      } else {
+        set({
+          nodes: [...defaultNodes],
+          edges: [...defaultEdges],
+          initialized: true
+        });
+        console.log('ストレージにデータがないため、デフォルト状態で初期化しました');
+      }
+    } catch (error) {
+      console.error('ストレージからの読み込み中にエラーが発生しました:', error);
+      set({
+        nodes: [...defaultNodes],
+        edges: [...defaultEdges],
+        initialized: true
+      });
+    }
+  },
+
+  // ストレージに保存
+  saveToStorage: () => {
+    const { nodes, edges } = get();
+    
+    // 初期化済みの場合のみ保存を実行
+    if (get().initialized) {
+      saveMindMapToStorage(nodes, edges);
+    }
+  }
 }));
 
 export default useStore;

--- a/src/components/layout/NavigationBar.tsx
+++ b/src/components/layout/NavigationBar.tsx
@@ -2,20 +2,23 @@ import React from 'react';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import FolderIcon from '@mui/icons-material/Folder';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
+import StorageIcon from '@mui/icons-material/Storage';
 import Tooltip from '@mui/material/Tooltip';
 
 interface NavigationBarProps {
   className?: string;
+  activeItem: string;
+  onItemClick: (item: string) => void;
 }
 
-const NavigationBar: React.FC<NavigationBarProps> = ({ className }) => {
-  // ナビゲーションアイテムのアクティブ状態を管理
-  const [activeItem, setActiveItem] = React.useState<string>('tree');
-
+const NavigationBar: React.FC<NavigationBarProps> = ({ 
+  className, 
+  activeItem = 'tree',
+  onItemClick
+}) => {
   // ナビゲーションアイテムをクリックした時の処理
   const handleItemClick = (item: string) => {
-    setActiveItem(item);
-    // 将来的には、ここでページ遷移や状態変更などの処理を追加
+    onItemClick(item);
   };
 
   return (
@@ -49,6 +52,15 @@ const NavigationBar: React.FC<NavigationBarProps> = ({ className }) => {
             onClick={() => handleItemClick('tree')}
           >
             <AccountTreeIcon sx={{ fontSize: 28 }} />
+          </button>
+        </Tooltip>
+        
+        <Tooltip title="ストレージ管理" placement="right" arrow>
+          <button 
+            className={`p-2 rounded-full transition-all duration-200 ${activeItem === 'storage' ? 'bg-orange-100 text-orange-600' : 'text-gray-600 hover:bg-gray-100'}`}
+            onClick={() => handleItemClick('storage')}
+          >
+            <StorageIcon sx={{ fontSize: 28 }} />
           </button>
         </Tooltip>
       </div>

--- a/src/components/layout/SidePanel.tsx
+++ b/src/components/layout/SidePanel.tsx
@@ -5,12 +5,15 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import SaveIcon from '@mui/icons-material/Save';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import DeleteIcon from '@mui/icons-material/Delete';
+import StorageIcon from '@mui/icons-material/Storage';
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import { NodeData } from '../../App/MindMapNode';
 import { useReactFlow } from 'reactflow';
 import { clearMindMapFromStorage } from '../../utils/storage';
 
 interface SidePanelProps {
   className?: string;
+  mode: string; // 'tree' or 'storage' or other modes
 }
 
 interface TreeNodeProps {
@@ -78,7 +81,38 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, nodes, level, reactFlowInstan
   );
 };
 
-const StorageSection: React.FC = () => {
+const TreeView: React.FC = () => {
+  // storeからノードを取得
+  const nodes = useStore(state => state.nodes);
+  const reactFlowInstance = useReactFlow();
+  
+  // 非表示でないルートノードを取得
+  const rootNodes = nodes.filter(node => !node.parentNode && !node.hidden);
+  
+  return (
+    <>
+      <div className="mb-2 pb-2 border-b border-gray-200">
+        <h2 className="text-sm font-semibold text-gray-700 flex items-center">
+          <AccountTreeIcon fontSize="small" className="mr-1" />
+          Todo ツリー
+        </h2>
+      </div>
+      <div className="space-y-1">
+        {rootNodes.map(node => (
+          <TreeNode 
+            key={node.id} 
+            node={node} 
+            nodes={nodes} 
+            level={0}
+            reactFlowInstance={reactFlowInstance}
+          />
+        ))}
+      </div>
+    </>
+  );
+};
+
+const StorageView: React.FC = () => {
   const saveToStorage = useStore(state => state.saveToStorage);
   const loadFromStorage = useStore(state => state.loadFromStorage);
   
@@ -100,65 +134,63 @@ const StorageSection: React.FC = () => {
   };
   
   return (
-    <div className="mt-4 pt-4 border-t border-gray-200">
-      <h2 className="text-sm font-semibold text-gray-700 mb-2">データ保存</h2>
-      <div className="flex flex-col space-y-2">
+    <>
+      <div className="mb-2 pb-2 border-b border-gray-200">
+        <h2 className="text-sm font-semibold text-gray-700 flex items-center">
+          <StorageIcon fontSize="small" className="mr-1" />
+          データ保存
+        </h2>
+      </div>
+
+      <div className="space-y-3 py-2">
+        <div className="text-xs text-gray-600 mb-2">
+          マインドマップは編集時に自動保存されます。
+          以下から手動操作も可能です。
+        </div>
+
         <button
           onClick={handleSave}
-          className="flex items-center text-xs px-2 py-1 rounded bg-blue-50 hover:bg-blue-100 text-blue-600"
+          className="flex items-center w-full justify-center text-sm px-3 py-2 rounded bg-blue-50 hover:bg-blue-100 text-blue-600"
         >
-          <SaveIcon fontSize="small" className="mr-1" />
+          <SaveIcon fontSize="small" className="mr-2" />
           手動保存
         </button>
+        
         <button
           onClick={handleLoad}
-          className="flex items-center text-xs px-2 py-1 rounded bg-green-50 hover:bg-green-100 text-green-600"
+          className="flex items-center w-full justify-center text-sm px-3 py-2 rounded bg-green-50 hover:bg-green-100 text-green-600"
         >
-          <RefreshIcon fontSize="small" className="mr-1" />
+          <RefreshIcon fontSize="small" className="mr-2" />
           再読み込み
         </button>
+        
         <button
           onClick={handleClear}
-          className="flex items-center text-xs px-2 py-1 rounded bg-red-50 hover:bg-red-100 text-red-600"
+          className="flex items-center w-full justify-center text-sm px-3 py-2 rounded bg-red-50 hover:bg-red-100 text-red-600"
         >
-          <DeleteIcon fontSize="small" className="mr-1" />
+          <DeleteIcon fontSize="small" className="mr-2" />
           データクリア
         </button>
-        <div className="text-xs text-gray-500 mt-1">
-          ※編集時は自動保存されています
+
+        <div className="mt-4 pt-4 border-t border-gray-200">
+          <h3 className="text-xs font-semibold text-gray-700 mb-2">保存データについて</h3>
+          <ul className="text-xs text-gray-600 space-y-1 list-disc pl-4">
+            <li>ブラウザのlocalStorageに保存されます</li>
+            <li>同じブラウザでのみ利用可能です</li>
+            <li>ブラウザの履歴を削除すると消える場合があります</li>
+          </ul>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 
-const SidePanel: React.FC<SidePanelProps> = ({ className }) => {
-  // storeからノードを取得
-  const nodes = useStore(state => state.nodes);
-  const reactFlowInstance = useReactFlow();
-  
-  // 非表示でないルートノードを取得
-  const rootNodes = nodes.filter(node => !node.parentNode && !node.hidden);
-  
+const SidePanel: React.FC<SidePanelProps> = ({ className, mode }) => {
+  // 現在のモードに基づいて表示内容を切り替え
   return (
     <div className={`fixed top-24 left-20 z-40 bg-white/95 backdrop-blur-sm shadow-md rounded-3xl p-3 max-w-xs w-64 max-h-[calc(100vh-140px)] overflow-auto border-2 border-gray-300 ${className || ''}`}>
-      <div className="mb-2 pb-2 border-b border-gray-200">
-        <h2 className="text-sm font-semibold text-gray-700">Todo ツリー</h2>
-      </div>
-      <div className="space-y-1">
-        {rootNodes.map(node => (
-          <TreeNode 
-            key={node.id} 
-            node={node} 
-            nodes={nodes} 
-            level={0}
-            reactFlowInstance={reactFlowInstance}
-          />
-        ))}
-      </div>
-      
-      {/* ストレージ管理セクション */}
-      <StorageSection />
+      {mode === 'tree' && <TreeView />}
+      {mode === 'storage' && <StorageView />}
     </div>
   );
 };

--- a/src/components/layout/SidePanel.tsx
+++ b/src/components/layout/SidePanel.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 import useStore from '../../App/store';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import SaveIcon from '@mui/icons-material/Save';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import DeleteIcon from '@mui/icons-material/Delete';
 import { NodeData } from '../../App/MindMapNode';
 import { useReactFlow } from 'reactflow';
+import { clearMindMapFromStorage } from '../../utils/storage';
 
 interface SidePanelProps {
   className?: string;
@@ -74,6 +78,60 @@ const TreeNode: React.FC<TreeNodeProps> = ({ node, nodes, level, reactFlowInstan
   );
 };
 
+const StorageSection: React.FC = () => {
+  const saveToStorage = useStore(state => state.saveToStorage);
+  const loadFromStorage = useStore(state => state.loadFromStorage);
+  
+  const handleSave = () => {
+    saveToStorage();
+    alert('マインドマップをlocalStorageに手動保存しました');
+  };
+  
+  const handleLoad = () => {
+    loadFromStorage();
+    alert('マインドマップをlocalStorageから再読み込みしました');
+  };
+  
+  const handleClear = () => {
+    if (window.confirm('マインドマップのデータをlocalStorageから削除しますか？\n(この操作は元に戻せません)')) {
+      clearMindMapFromStorage();
+      alert('マインドマップのデータをlocalStorageから削除しました。\n再読み込みするとデフォルト状態に戻ります。');
+    }
+  };
+  
+  return (
+    <div className="mt-4 pt-4 border-t border-gray-200">
+      <h2 className="text-sm font-semibold text-gray-700 mb-2">データ保存</h2>
+      <div className="flex flex-col space-y-2">
+        <button
+          onClick={handleSave}
+          className="flex items-center text-xs px-2 py-1 rounded bg-blue-50 hover:bg-blue-100 text-blue-600"
+        >
+          <SaveIcon fontSize="small" className="mr-1" />
+          手動保存
+        </button>
+        <button
+          onClick={handleLoad}
+          className="flex items-center text-xs px-2 py-1 rounded bg-green-50 hover:bg-green-100 text-green-600"
+        >
+          <RefreshIcon fontSize="small" className="mr-1" />
+          再読み込み
+        </button>
+        <button
+          onClick={handleClear}
+          className="flex items-center text-xs px-2 py-1 rounded bg-red-50 hover:bg-red-100 text-red-600"
+        >
+          <DeleteIcon fontSize="small" className="mr-1" />
+          データクリア
+        </button>
+        <div className="text-xs text-gray-500 mt-1">
+          ※編集時は自動保存されています
+        </div>
+      </div>
+    </div>
+  );
+};
+
 const SidePanel: React.FC<SidePanelProps> = ({ className }) => {
   // storeからノードを取得
   const nodes = useStore(state => state.nodes);
@@ -98,6 +156,9 @@ const SidePanel: React.FC<SidePanelProps> = ({ className }) => {
           />
         ))}
       </div>
+      
+      {/* ストレージ管理セクション */}
+      <StorageSection />
     </div>
   );
 };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,123 +1,95 @@
-/**
- * Storage utility functions for data persistence
- * 
- * This module provides an abstracted interface for data storage operations,
- * currently implemented with localStorage but designed to be extended to other
- * storage solutions (iCloud, Google Drive, GitHub, etc.) in the future.
- */
+import { Edge, Node } from 'reactflow';
+import { NodeData } from '../App/MindMapNode';
 
-// Keys used for localStorage
-export const STORAGE_KEYS = {
-  MINDMAP_DATA: 'mindmap-todo-data',
-  LAST_MODIFIED: 'mindmap-todo-last-modified',
+// LocalStorageのキー
+const STORAGE_KEY = 'mindmap-todo-data';
+
+// 保存するデータの型定義
+export interface MindMapStorageData {
+  nodes: Node<NodeData>[];
+  edges: Edge[];
+  lastSaved: number; // タイムスタンプ
+}
+
+/**
+ * マインドマップデータをlocalStorageに保存する
+ */
+export const saveMindMapToStorage = (nodes: Node<NodeData>[], edges: Edge[]): void => {
+  try {
+    const data: MindMapStorageData = {
+      nodes,
+      edges,
+      lastSaved: Date.now()
+    };
+    
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    console.log('マインドマップをlocalStorageに保存しました', new Date().toLocaleTimeString());
+  } catch (error) {
+    console.error('マインドマップの保存に失敗しました:', error);
+  }
 };
 
 /**
- * Storage interface defining the contract for all storage implementations
+ * localStorageからマインドマップデータを読み込む
+ */
+export const loadMindMapFromStorage = (): MindMapStorageData | null => {
+  try {
+    const storedData = localStorage.getItem(STORAGE_KEY);
+    
+    if (!storedData) {
+      return null;
+    }
+    
+    const parsedData: MindMapStorageData = JSON.parse(storedData);
+    console.log('マインドマップをlocalStorageから読み込みました', new Date(parsedData.lastSaved).toLocaleString());
+    return parsedData;
+  } catch (error) {
+    console.error('マインドマップの読み込みに失敗しました:', error);
+    return null;
+  }
+};
+
+/**
+ * localStorageからマインドマップデータを削除する
+ */
+export const clearMindMapFromStorage = (): void => {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+    console.log('マインドマップのストレージデータをクリアしました');
+  } catch (error) {
+    console.error('マインドマップデータの削除に失敗しました:', error);
+  }
+};
+
+/**
+ * ストレージプロバイダーのインターフェース
+ * 将来的なクラウドストレージ連携を見据えたインターフェース定義
  */
 export interface StorageProvider {
-  // Save data to storage
-  save: <T>(key: string, data: T) => Promise<void>;
-  
-  // Load data from storage
-  load: <T>(key: string) => Promise<T | null>;
-  
-  // Check if data exists in storage
-  exists: (key: string) => Promise<boolean>;
-  
-  // Delete data from storage
-  delete: (key: string) => Promise<void>;
+  save(data: MindMapStorageData): Promise<void>;
+  load(): Promise<MindMapStorageData | null>;
+  clear(): Promise<void>;
 }
 
 /**
- * localStorage implementation of the StorageProvider interface
+ * LocalStorage プロバイダーの実装
  */
 export class LocalStorageProvider implements StorageProvider {
-  /**
-   * Save data to localStorage
-   * @param key - Storage key
-   * @param data - Data to store
-   */
-  async save<T>(key: string, data: T): Promise<void> {
-    try {
-      const serializedData = JSON.stringify(data);
-      localStorage.setItem(key, serializedData);
-      // Update last modified timestamp
-      localStorage.setItem(STORAGE_KEYS.LAST_MODIFIED, Date.now().toString());
-    } catch (error) {
-      console.error('Error saving to localStorage:', error);
-      throw new Error('Failed to save data to localStorage');
-    }
+  async save(data: MindMapStorageData): Promise<void> {
+    saveMindMapToStorage(data.nodes, data.edges);
   }
 
-  /**
-   * Load data from localStorage
-   * @param key - Storage key
-   * @returns The stored data or null if not found
-   */
-  async load<T>(key: string): Promise<T | null> {
-    try {
-      const data = localStorage.getItem(key);
-      if (!data) return null;
-      return JSON.parse(data) as T;
-    } catch (error) {
-      console.error('Error loading from localStorage:', error);
-      throw new Error('Failed to load data from localStorage');
-    }
+  async load(): Promise<MindMapStorageData | null> {
+    return loadMindMapFromStorage();
   }
 
-  /**
-   * Check if data exists in localStorage
-   * @param key - Storage key
-   * @returns True if data exists, false otherwise
-   */
-  async exists(key: string): Promise<boolean> {
-    return localStorage.getItem(key) !== null;
-  }
-
-  /**
-   * Delete data from localStorage
-   * @param key - Storage key
-   */
-  async delete(key: string): Promise<void> {
-    localStorage.removeItem(key);
+  async clear(): Promise<void> {
+    clearMindMapFromStorage();
   }
 }
 
-// Default storage provider instance (localStorage)
-const storageProvider = new LocalStorageProvider();
-
-/**
- * Save mindmap data to storage
- * @param data - Mindmap data to store
- */
-export const saveMindMapData = async <T>(data: T): Promise<void> => {
-  await storageProvider.save(STORAGE_KEYS.MINDMAP_DATA, data);
+// デフォルトのストレージプロバイダーを返す関数
+// 将来的にはユーザー設定などに基づいて異なるプロバイダーを返すことができる
+export const getStorageProvider = (): StorageProvider => {
+  return new LocalStorageProvider();
 };
-
-/**
- * Load mindmap data from storage
- * @returns The stored mindmap data or null if not found
- */
-export const loadMindMapData = async <T>(): Promise<T | null> => {
-  return await storageProvider.load<T>(STORAGE_KEYS.MINDMAP_DATA);
-};
-
-/**
- * Check if mindmap data exists in storage
- * @returns True if data exists, false otherwise
- */
-export const hasMindMapData = async (): Promise<boolean> => {
-  return await storageProvider.exists(STORAGE_KEYS.MINDMAP_DATA);
-};
-
-/**
- * Get the last modified timestamp for mindmap data
- * @returns Timestamp or null if not available
- */
-export const getLastModifiedTime = async (): Promise<number | null> => {
-  const timestamp = await storageProvider.load<string>(STORAGE_KEYS.LAST_MODIFIED);
-  return timestamp ? parseInt(timestamp, 10) : null;
-};
-
-export default storageProvider;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,123 @@
+/**
+ * Storage utility functions for data persistence
+ * 
+ * This module provides an abstracted interface for data storage operations,
+ * currently implemented with localStorage but designed to be extended to other
+ * storage solutions (iCloud, Google Drive, GitHub, etc.) in the future.
+ */
+
+// Keys used for localStorage
+export const STORAGE_KEYS = {
+  MINDMAP_DATA: 'mindmap-todo-data',
+  LAST_MODIFIED: 'mindmap-todo-last-modified',
+};
+
+/**
+ * Storage interface defining the contract for all storage implementations
+ */
+export interface StorageProvider {
+  // Save data to storage
+  save: <T>(key: string, data: T) => Promise<void>;
+  
+  // Load data from storage
+  load: <T>(key: string) => Promise<T | null>;
+  
+  // Check if data exists in storage
+  exists: (key: string) => Promise<boolean>;
+  
+  // Delete data from storage
+  delete: (key: string) => Promise<void>;
+}
+
+/**
+ * localStorage implementation of the StorageProvider interface
+ */
+export class LocalStorageProvider implements StorageProvider {
+  /**
+   * Save data to localStorage
+   * @param key - Storage key
+   * @param data - Data to store
+   */
+  async save<T>(key: string, data: T): Promise<void> {
+    try {
+      const serializedData = JSON.stringify(data);
+      localStorage.setItem(key, serializedData);
+      // Update last modified timestamp
+      localStorage.setItem(STORAGE_KEYS.LAST_MODIFIED, Date.now().toString());
+    } catch (error) {
+      console.error('Error saving to localStorage:', error);
+      throw new Error('Failed to save data to localStorage');
+    }
+  }
+
+  /**
+   * Load data from localStorage
+   * @param key - Storage key
+   * @returns The stored data or null if not found
+   */
+  async load<T>(key: string): Promise<T | null> {
+    try {
+      const data = localStorage.getItem(key);
+      if (!data) return null;
+      return JSON.parse(data) as T;
+    } catch (error) {
+      console.error('Error loading from localStorage:', error);
+      throw new Error('Failed to load data from localStorage');
+    }
+  }
+
+  /**
+   * Check if data exists in localStorage
+   * @param key - Storage key
+   * @returns True if data exists, false otherwise
+   */
+  async exists(key: string): Promise<boolean> {
+    return localStorage.getItem(key) !== null;
+  }
+
+  /**
+   * Delete data from localStorage
+   * @param key - Storage key
+   */
+  async delete(key: string): Promise<void> {
+    localStorage.removeItem(key);
+  }
+}
+
+// Default storage provider instance (localStorage)
+const storageProvider = new LocalStorageProvider();
+
+/**
+ * Save mindmap data to storage
+ * @param data - Mindmap data to store
+ */
+export const saveMindMapData = async <T>(data: T): Promise<void> => {
+  await storageProvider.save(STORAGE_KEYS.MINDMAP_DATA, data);
+};
+
+/**
+ * Load mindmap data from storage
+ * @returns The stored mindmap data or null if not found
+ */
+export const loadMindMapData = async <T>(): Promise<T | null> => {
+  return await storageProvider.load<T>(STORAGE_KEYS.MINDMAP_DATA);
+};
+
+/**
+ * Check if mindmap data exists in storage
+ * @returns True if data exists, false otherwise
+ */
+export const hasMindMapData = async (): Promise<boolean> => {
+  return await storageProvider.exists(STORAGE_KEYS.MINDMAP_DATA);
+};
+
+/**
+ * Get the last modified timestamp for mindmap data
+ * @returns Timestamp or null if not available
+ */
+export const getLastModifiedTime = async (): Promise<number | null> => {
+  const timestamp = await storageProvider.load<string>(STORAGE_KEYS.LAST_MODIFIED);
+  return timestamp ? parseInt(timestamp, 10) : null;
+};
+
+export default storageProvider;


### PR DESCRIPTION
## 対応内容
マインドマップの自動保存機能を実装し、localStorageにデータを保存・復元できるようにしました。

### 主な変更点
1. ストレージ操作用のユーティリティモジュールを作成
   - localStorageへの保存/読込/削除機能
   - 将来的な拡張を見据えたインターフェース設計

2. storeに保存/読込機能を追加
   - ノード/エッジの変更時に自動保存
   - 初期化時にストレージからデータ読込

3. UIコンポーネントの更新
   - SidePanelにストレージ管理セクションを追加
     - 手動保存
     - 再読込
     - データクリア

### 動作説明
- マインドマップ編集時に自動保存
- ブラウザを閉じて再訪問しても前回の状態を復元
- サイドパネルから手動での保存/読込/クリア操作が可能

### 今後の拡張性
ストレージプロバイダーインターフェースを用意することで、将来的に以下の連携が容易になります：
- iCloud連携
- Google Drive連携
- GitHub連携

## スクリーンショット
なし

## テスト方法
1. マインドマップを編集（ノード追加/変更）
2. ブラウザをリロードし、状態が保持されているか確認
3. サイドパネルの保存機能を使用して動作確認

## 検証結果
- 編集時の自動保存: ✅
- 再訪問時の状態復元: ✅
- 手動保存/読込/クリア: ✅

## 今後の課題
- localStorageの容量制限への対応
- 同期エラー時の競合解決
- クラウドストレージ連携の実装