### PR TITLE
MMT-2: ノードアクション機能の実装

### DIFF
--- a/src/App/MindMapNode/index.tsx
+++ b/src/App/MindMapNode/index.tsx
@@ -1,7 +1,9 @@
-import { useLayoutEffect, useEffect, useRef } from 'react';
+import { useLayoutEffect, useEffect, useRef, useState } from 'react';
 import { Handle, NodeProps, Position } from 'reactflow';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
 
 import useStore from '../store';
 
@@ -17,9 +19,17 @@ function MindMapNode({ id, data }: NodeProps<NodeData>) {
   const updateNodeLabel = useStore((state) => state.updateNodeLabel);
   const toggleNodeCollapse = useStore((state) => state.toggleNodeCollapse);
   const nodes = useStore((state) => state.nodes);
+  const selectedNodeId = useStore((state) => state.selectedNodeId);
+  const selectNode = useStore((state) => state.selectNode);
+  const deleteNode = useStore((state) => state.deleteNode);
+  const addChildNodeDirectly = useStore((state) => state.addChildNodeDirectly);
   
   // 子ノードを持っているか確認
   const hasChildren = nodes.some(node => node.parentNode === id);
+  // 現在のノードが選択されているか
+  const isSelected = selectedNodeId === id;
+  // ルートノードかどうかを確認
+  const isRootNode = id === 'root';
 
   useEffect(() => {
     setTimeout(() => {
@@ -59,9 +69,42 @@ function MindMapNode({ id, data }: NodeProps<NodeData>) {
     e.stopPropagation();
     toggleNodeCollapse(id);
   };
+  
+  const handleNodeClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    
+    // すでに選択されている場合は選択解除
+    if (isSelected) {
+      selectNode(null);
+    } else {
+      // 他のノードを選択
+      selectNode(id);
+    }
+  };
+  
+  const handleDeleteNode = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    deleteNode(id);
+  };
+  
+  const handleAddChildNode = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    addChildNodeDirectly(id);
+  };
+  
+  const handleInputClick = (e: React.MouseEvent) => {
+    // 編集モードの際にイベントが親に伝播しないようにする
+    e.stopPropagation();
+  };
+  
+  // 選択されている場合のスタイルクラス
+  const selectedClass = isSelected ? "node-selected" : "";
 
   return (
-    <>
+    <div 
+      className={`node-container ${selectedClass}`} 
+      onClick={handleNodeClick}
+    >
       <div className="inputWrapper">
         <div className="dragHandle">
           <DragIcon />
@@ -71,6 +114,7 @@ function MindMapNode({ id, data }: NodeProps<NodeData>) {
           onChange={(evt) => updateNodeLabel(id, evt.target.value)}
           className="input"
           ref={inputRef}
+          onClick={handleInputClick}
         />
         {hasChildren && (
           <div className="collapseButton" onClick={handleToggleCollapse}>
@@ -81,10 +125,34 @@ function MindMapNode({ id, data }: NodeProps<NodeData>) {
           </div>
         )}
       </div>
+      
+      {/* 選択状態の時に表示するアクションメニュー */}
+      {isSelected && (
+        <div className="action-menu">
+          <button 
+            className="action-button add-button"
+            onClick={handleAddChildNode}
+            title="Add child node"
+          >
+            <AddIcon fontSize="small" />
+          </button>
+          
+          {/* ルートノードは削除できないようにする */}
+          {!isRootNode && (
+            <button 
+              className="action-button delete-button"
+              onClick={handleDeleteNode}
+              title="Delete node"
+            >
+              <DeleteIcon fontSize="small" />
+            </button>
+          )}
+        </div>
+      )}
 
       <Handle type="target" position={Position.Top} />
       <Handle type="source" position={Position.Top} />
-    </>
+    </div>
   );
 }
 

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -33,6 +33,8 @@ const selector = (state: RFState) => ({
   loadFromStorage: state.loadFromStorage,
   initialized: state.initialized,
   setInitialized: state.setInitialized,
+  selectNode: state.selectNode,
+  selectedNodeId: state.selectedNodeId,
 });
 
 const nodeTypes = {
@@ -58,7 +60,9 @@ function Flow() {
     addChildNode,
     loadFromStorage,
     initialized,
-    setInitialized
+    setInitialized,
+    selectNode,
+    selectedNodeId
   } = useStore(selector, shallow);
   
   const [connectingNodeId, setConnectingNodeId] = useState<string | null>(null);
@@ -179,6 +183,13 @@ function Flow() {
       setShowSidePanel(false);
     }
   };
+  
+  // 背景クリック時に選択状態をクリア
+  const onPaneClick = useCallback(() => {
+    if (selectedNodeId) {
+      selectNode(null);
+    }
+  }, [selectedNodeId, selectNode]);
 
   return (
     <div className="flex h-screen">
@@ -208,6 +219,7 @@ function Flow() {
           fitView
           minZoom={0.2}
           maxZoom={1.5}
+          onPaneClick={onPaneClick}
         >
           <Header onSearch={handleSearch} />
           {showSidePanel && <SidePanel mode={sidePanelMode} />}

--- a/src/App/store.ts
+++ b/src/App/store.ts
@@ -27,6 +27,10 @@ export type RFState = {
   saveToStorage: () => void;
   initialized: boolean;
   setInitialized: (value: boolean) => void;
+  selectedNodeId: string | null;
+  selectNode: (nodeId: string | null) => void;
+  deleteNode: (nodeId: string) => void;
+  addChildNodeDirectly: (parentNodeId: string) => void;
 };
 
 // デフォルトのノードとエッジ
@@ -49,6 +53,9 @@ const useStore = create<RFState>((set, get) => ({
   // デフォルト値で初期化
   nodes: [...defaultNodes],
   edges: [...defaultEdges],
+  
+  // 選択されたノードのID
+  selectedNodeId: null,
 
   // ノード変更
   onNodesChange: (changes: NodeChange[]) => {
@@ -107,6 +114,45 @@ const useStore = create<RFState>((set, get) => ({
     set({
       nodes: [...get().nodes, newNode],
       edges: [...get().edges, newEdge],
+    });
+    
+    // 変更があった時に自動保存
+    setTimeout(() => get().saveToStorage(), 0);
+  },
+  
+  // 子ノードを指定した親ノードに直接追加（ボタンクリック用）
+  addChildNodeDirectly: (parentNodeId: string) => {
+    // 親ノードを取得
+    const parentNode = get().nodes.find(node => node.id === parentNodeId);
+    if (!parentNode) return;
+    
+    // 親ノードの位置を基準に新しい位置を計算
+    // 親ノードの下に配置
+    const position = {
+      x: 0, // 相対位置なのでx=0で親ノードの中央
+      y: 80, // 親ノードの下に80px離れた位置
+    };
+    
+    const newNode = {
+      id: nanoid(),
+      type: 'mindmap',
+      data: { label: 'New Node', collapsed: false },
+      position,
+      parentNode: parentNodeId,
+      dragHandle: '.dragHandle',
+    };
+
+    const newEdge = {
+      id: nanoid(),
+      source: parentNodeId,
+      target: newNode.id,
+    };
+
+    set({
+      nodes: [...get().nodes, newNode],
+      edges: [...get().edges, newEdge],
+      // 新しく作成したノードを選択状態にする
+      selectedNodeId: newNode.id
     });
     
     // 変更があった時に自動保存
@@ -175,6 +221,57 @@ const useStore = create<RFState>((set, get) => ({
     set({ 
       nodes: updatedNodes,
       edges: updatedEdges
+    });
+    
+    // 変更があった時に自動保存
+    setTimeout(() => get().saveToStorage(), 0);
+  },
+  
+  // ノード選択
+  selectNode: (nodeId: string | null) => {
+    set({ selectedNodeId: nodeId });
+  },
+  
+  // ノード削除
+  deleteNode: (nodeId: string) => {
+    // ルートノードは削除不可
+    if (nodeId === 'root') return;
+    
+    // 削除対象ノードの子孫IDを再帰的に取得
+    const getDescendantIds = (targetId: string): string[] => {
+      const directChildren = get().nodes
+        .filter((node) => node.parentNode === targetId)
+        .map((node) => node.id);
+      
+      const allDescendants = [...directChildren];
+      
+      directChildren.forEach((childId) => {
+        allDescendants.push(...getDescendantIds(childId));
+      });
+      
+      return allDescendants;
+    };
+    
+    // 削除するノードの子孫を含む全ノードID
+    const descendantIds = getDescendantIds(nodeId);
+    const allNodeIdsToDelete = [nodeId, ...descendantIds];
+    
+    // 削除対象ノードとその子孫を除外したノード配列を作成
+    const updatedNodes = get().nodes.filter(
+      (node) => !allNodeIdsToDelete.includes(node.id)
+    );
+    
+    // 削除対象ノードに関連するエッジを除外したエッジ配列を作成
+    const updatedEdges = get().edges.filter(
+      (edge) => 
+        !allNodeIdsToDelete.includes(edge.source) && 
+        !allNodeIdsToDelete.includes(edge.target)
+    );
+    
+    set({
+      nodes: updatedNodes,
+      edges: updatedEdges,
+      selectedNodeId: null, // 選択状態をクリア
     });
     
     // 変更があった時に自動保存

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,7 @@ body,
   border: none;
   padding: 6px 10px;
   font-weight: 700;
+  transition: all 0.2s ease;
 }
 
 .react-flow__handle.target {
@@ -48,6 +49,12 @@ body,
 
 .react-flow .react-flow__connectionline {
   z-index: 0;
+}
+
+.node-container {
+  width: 100%;
+  position: relative;
+  transition: all 0.2s ease;
 }
 
 .inputWrapper {
@@ -129,4 +136,71 @@ body,
   100% {
     box-shadow: 0 0 0 2px #f6ad55, 0 0 10px 2px rgba(246, 173, 85, 0.5);
   }
+}
+
+/* 選択状態のノードのスタイル */
+.node-selected {
+  transform: scale(1.05);
+  z-index: 20;
+}
+
+.react-flow__node-mindmap .node-selected {
+  box-shadow: 0 0 0 2px #58a6ff, 0 0 8px 2px rgba(88, 166, 255, 0.4);
+}
+
+/* アクションメニュー */
+.action-menu {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 4px;
+  background-color: rgba(255, 255, 255, 0.9);
+  border-radius: 4px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  opacity: 0;
+  transform: translateY(-5px);
+  transition: all 0.2s ease;
+  pointer-events: all;
+  animation: fadeIn 0.2s forwards;
+}
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.action-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 14px;
+}
+
+.add-button {
+  background-color: #e6f7ff;
+  color: #1890ff;
+}
+
+.add-button:hover {
+  background-color: #1890ff;
+  color: white;
+}
+
+.delete-button {
+  background-color: #fff1f0;
+  color: #ff4d4f;
+}
+
+.delete-button:hover {
+  background-color: #ff4d4f;
+  color: white;
 }


### PR DESCRIPTION
## 実装内容
ノードタップで選択状態を切り替え、選択されたノードにアクションボタンを表示する機能を実装しました。

### 機能詳細
1. **ノード選択機能**
   - ノードをタップすると選択状態になり、少し拡大表示されます
   - 同時に1つのノードのみ選択可能で、背景クリックで選択解除されます
   - 選択されたノードは青いハイライトで視覚的に区別されます

2. **アクションボタン**
   - 選択状態のノードには下部にアクションボタンが表示されます
   - 「子ノード追加」ボタン: クリックで親ノードの下に新しいノードを作成
   - 「削除」ボタン: ノードとその子孫をすべて削除（ルートノードは削除不可）

3. **状態管理の拡張**
   - storeに選択状態管理と削除機能を追加
   - ノード選択時の視覚的フィードバックのためのスタイル追加
   - アクションボタンのスタイル定義

### 視覚的な効果
- ノード選択時に僅かに拡大され、青いハイライトで強調
- アクションボタンはフェードインアニメーションで表示
- ボタンはホバー時に色が変化し、インタラクティブな感覚を提供

### 技術的な実装
- zustandストアで選択状態を管理
- ReactFlowのonPaneClickイベントを利用した選択解除
- CSSアニメーションによる滑らかな視覚効果
- ノード削除時の子孫ノード処理のロジック

## スクリーンショット
なし

## テスト方法
1. ノードをタップして選択状態になることを確認
2. 選択状態でアクションボタンが表示されることを確認
3. 子ノード追加ボタンで新しいノードが作成されることを確認
4. 削除ボタンでノードが削除されることを確認
5. 背景クリックで選択状態が解除されることを確認
6. ルートノードでは削除ボタンが表示されないことを確認